### PR TITLE
Set `meta.type` to "layout"

### DIFF
--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -120,6 +120,7 @@ module.exports = {
         docs: {
           url: 'https://github.com/prettier/eslint-plugin-prettier#options'
         },
+        type: 'layout',
         fixable: 'code',
         schema: [
           // Prettier options:


### PR DESCRIPTION
Per https://eslint.org/docs/user-guide/command-line-interface#fix-type , one can set `meta` to "problem" or "suggestion" for code-related changes or "layout" for formatting ones. Setting this value allows `eslint --fix-type` to take into account the type of fix desired. (And I'm making an eslint badge formatter for which it is more convenient to have this meta info so any rule violations can be grouped by type.)